### PR TITLE
Use \[CurlyEpsilon] instead of \[Epsilon]

### DIFF
--- a/DualNumbers/Kernel/Definitions.wl
+++ b/DualNumbers/Kernel/Definitions.wl
@@ -27,20 +27,20 @@ GeneralUtilities`SetUsage[StandardAll,
     "StandardAll[expr$] replaces all dual numbers in expr$ with their standard parts."
 ];
 GeneralUtilities`SetUsage[DualExpand,
-    "DualExpand[expr$] replaces each dual number Dual[a$, b$] with a$ + b$ \[Epsilon].
+    "DualExpand[expr$] replaces each dual number Dual[a$, b$] with a$ + b$ \[CurlyEpsilon].
 DualExpand[expr$, eps$] uses eps$ instead."
 ];
 GeneralUtilities`SetUsage[DualFactor,
-    "DualFactor[expr$] replaces \[Epsilon] with Dual[0, 1] in expr$.
+    "DualFactor[expr$] replaces \[CurlyEpsilon] with Dual[0, 1] in expr$.
 DualFactor[expr$, eps$] uses eps$ instead.
 "
 ];
 GeneralUtilities`SetUsage[DualSimplify,
-    "DualSimplify[expr$] expands expr$ around \[Epsilon] = 0, keeping only the 0th and 1st order terms.
+    "DualSimplify[expr$] expands expr$ around \[CurlyEpsilon] = 0, keeping only the 0th and 1st order terms.
 DualSimplify[expr$, eps$] uses eps$ as symbol for the dual unit.
 "
 ];
-GeneralUtilities`SetUsage[\[Epsilon], "\[Epsilon] is an inactive form of Dual[0, 1] that can be used for algebraic manipulation."];
+GeneralUtilities`SetUsage[\[CurlyEpsilon], "\[CurlyEpsilon] is an inactive form of Dual[0, 1] that can be used for algebraic manipulation."];
 GeneralUtilities`SetUsage[DualQ, "DualQ[expr$] tests if expr$ is a dual number."];
 GeneralUtilities`SetUsage[DualScalarQ, "DualQ[expr$] tests if expr$ is a dual number but not a dual array."];
 GeneralUtilities`SetUsage[DualArrayQ, "DualArrayQ[expr$] tests if expr$ is a valid packed array of dual numbers."];
@@ -109,7 +109,7 @@ Begin["`Private`"] (* Begin Private Context *)
     Code inspired by the following post on Mathematica StackExchange:
     https://mathematica.stackexchange.com/a/13926/43522
 *)
-Protect[\[Epsilon]];
+Protect[\[CurlyEpsilon]];
 
 derivativePatt = Except[Function[D[__]], _Function];
 arrayPattern = _List | _SparseArray;

--- a/DualNumbers/Kernel/HelperFunctions.wl
+++ b/DualNumbers/Kernel/HelperFunctions.wl
@@ -23,13 +23,13 @@ Begin["`Private`"] (* Begin Private Context *)
 (* Manipulating expressions with dual numbers *)
 StandardAll[expr_] := ReplaceRepeated[expr, Dual[a_, _] :> a];
 
-DualExpand[expr_, eps : _ : \[Epsilon]] := ReplaceRepeated[
+DualExpand[expr_, eps : _ : \[CurlyEpsilon]] := ReplaceRepeated[
     expr,
     Dual[a_, b_] :> a + b * eps
 ];
-DualFactor[expr_, eps : _ : \[Epsilon]] := ReplaceRepeated[expr, eps :> Dual[0, 1]];
+DualFactor[expr_, eps : _ : \[CurlyEpsilon]] := ReplaceRepeated[expr, eps :> Dual[0, 1]];
 
-DualSimplify[expr_, eps : _ : \[Epsilon]] := Normal @ Series[expr, {eps, 0, 1}];
+DualSimplify[expr_, eps : _ : \[CurlyEpsilon]] := Normal @ Series[expr, {eps, 0, 1}];
 
 With[{
     cf1 = Compile[{

--- a/Example_code.nb
+++ b/Example_code.nb
@@ -52,7 +52,7 @@ Cell[TextData[{
   "740093c7-9dd4-4714-9ed4-8beeb34abeee"],
  " as a series in ",
  Cell[BoxData[
-  FormBox["\[Epsilon]", TraditionalForm]],ExpressionUUID->
+  FormBox["\[CurlyEpsilon]", TraditionalForm]],ExpressionUUID->
   "379162a3-f901-413a-935e-289e5b37aa00"]
 }], "Text",ExpressionUUID->"d212c0cc-0228-4e55-8dfe-a522fe2bf7b0"],
 
@@ -65,12 +65,12 @@ Cell[BoxData[
     RowBox[{
      RowBox[{"f", "[", 
       RowBox[{"a", "+", 
-       RowBox[{"b", " ", "\[Epsilon]"}]}], "]"}], ",", 
+       RowBox[{"b", " ", "\[CurlyEpsilon]"}]}], "]"}], ",", 
      RowBox[{"{", 
-      RowBox[{"\[Epsilon]", ",", "0", ",", "4"}], "}"}]}], "]"}]}], "/.", 
+      RowBox[{"\[CurlyEpsilon]", ",", "0", ",", "4"}], "}"}]}], "]"}]}], "/.", 
   RowBox[{
    RowBox[{"Power", "[", 
-    RowBox[{"\[Epsilon]", ",", 
+    RowBox[{"\[CurlyEpsilon]", ",", 
      RowBox[{"_", "?", 
       RowBox[{"(", 
        RowBox[{"GreaterEqualThan", "[", "2", "]"}], ")"}]}]}], "]"}], 
@@ -80,7 +80,7 @@ Cell[BoxData[
 Cell[BoxData[
  RowBox[{
   RowBox[{"f", "[", "a", "]"}], "+", 
-  RowBox[{"b", " ", "\[Epsilon]", " ", 
+  RowBox[{"b", " ", "\[CurlyEpsilon]", " ", 
    RowBox[{
     SuperscriptBox["f", "\[Prime]",
      MultilineFunction->None], "[", "a", "]"}]}]}]], "Output",
@@ -102,13 +102,13 @@ Cell[BoxData[
  RowBox[{"DualSimplify", "[", 
   RowBox[{"f", "[", 
    RowBox[{"a", "+", 
-    RowBox[{"b", " ", "\[Epsilon]"}]}], "]"}], "]"}]], "Input",
+    RowBox[{"b", " ", "\[CurlyEpsilon]"}]}], "]"}], "]"}]], "Input",
  CellLabel->"In[72]:=",ExpressionUUID->"a9a4f68a-8e77-483e-a5fd-6bc860934c0f"],
 
 Cell[BoxData[
  RowBox[{
   RowBox[{"f", "[", "a", "]"}], "+", 
-  RowBox[{"b", " ", "\[Epsilon]", " ", 
+  RowBox[{"b", " ", "\[CurlyEpsilon]", " ", 
    RowBox[{
     SuperscriptBox["f", "\[Prime]",
      MultilineFunction->None], "[", "a", "]"}]}]}]], "Output",
@@ -6905,7 +6905,7 @@ Cell["Symbolic manipulation of dual numbers", \
 Cell[CellGroupData[{
 
 Cell[BoxData[{
- RowBox[{"?", "\[Epsilon]"}], "\[IndentingNewLine]", 
+ RowBox[{"?", "\[CurlyEpsilon]"}], "\[IndentingNewLine]", 
  RowBox[{"?", "DualExpand"}], "\[IndentingNewLine]", 
  RowBox[{"?", "DualFactor"}], "\[IndentingNewLine]", 
  RowBox[{"?", "DualSimplify"}], "\[IndentingNewLine]"}], "Input",
@@ -6935,7 +6935,7 @@ Cell[BoxData[
           ItemBox[
            PaneBox[
             
-            StyleBox["\<\"\[Epsilon] is an inactive form of Dual[0, 1] that \
+            StyleBox["\<\"\[CurlyEpsilon] is an inactive form of Dual[0, 1] that \
 can be used for algebraic manipulation.\"\>", "InformationUsageText",
              StripOnInput->False,
              LineSpacing->{1.5, 1.5, 3.}],
@@ -6971,7 +6971,7 @@ can be used for algebraic manipulation.\"\>", "InformationUsageText",
                     TooltipStyle->"TextStyling"],
                     
                     Annotation[#, "FullName", 
-                    "Tooltip"]& ], "\<\"DualNumbers`\[Epsilon]\"\>"}
+                    "Tooltip"]& ], "\<\"DualNumbers`\[CurlyEpsilon]\"\>"}
                  },
                  AutoDelete->False,
                  GridBoxAlignment->{"Columns" -> {Right, Left}},
@@ -7060,7 +7060,7 @@ can be used for algebraic manipulation.\"\>", "InformationUsageText",
           ItemBox[
            PaneBox[
             
-            StyleBox["\<\"\[Epsilon] is an inactive form of Dual[0, 1] that \
+            StyleBox["\<\"\[CurlyEpsilon] is an inactive form of Dual[0, 1] that \
 can be used for algebraic manipulation.\"\>", "InformationUsageText",
              StripOnInput->False,
              LineSpacing->{1.5, 1.5, 3.}],
@@ -7125,12 +7125,12 @@ can be used for algebraic manipulation.\"\>", "InformationUsageText",
   InformationData[
    Association[
    "ObjectType" -> "Symbol", "Usage" -> 
-    "\[Epsilon] is an inactive form of Dual[0, 1] that can be used for \
+    "\[CurlyEpsilon] is an inactive form of Dual[0, 1] that can be used for \
 algebraic manipulation.", "Documentation" -> None, "OwnValues" -> None, 
     "UpValues" -> None, "DownValues" -> None, "SubValues" -> None, 
     "DefaultValues" -> None, "NValues" -> None, "FormatValues" -> None, 
     "Options" -> None, "Attributes" -> {Protected}, "FullName" -> 
-    "DualNumbers`\[Epsilon]"], False]]], "Output",
+    "DualNumbers`\[CurlyEpsilon]"], False]]], "Output",
  CellLabel->"Out[45]=",ExpressionUUID->"2bb62ef2-fb75-417b-ba06-ca42cc3a6678"],
 
 Cell[BoxData[
@@ -7162,7 +7162,7 @@ RowBox[{StyleBox[\\\"expr\\\", \\\"TI\\\"]}], \\\"]\\\"}]\\) replaces each \
 dual number Dual[\\!\\(\\*StyleBox[\\\"a\\\", \\\"TI\\\"]\\), \
 \\!\\(\\*StyleBox[\\\"b\\\", \\\"TI\\\"]\\)] with \
 \\!\\(\\*StyleBox[\\\"a\\\", \\\"TI\\\"]\\) + \\!\\(\\*StyleBox[\\\"b\\\", \\\
-\"TI\\\"]\\) \[Epsilon].\\n\\!\\(\\*RowBox[{\\\"DualExpand\\\", \\\"[\\\", \
+\"TI\\\"]\\) \[CurlyEpsilon].\\n\\!\\(\\*RowBox[{\\\"DualExpand\\\", \\\"[\\\", \
 RowBox[{StyleBox[\\\"expr\\\", \\\"TI\\\"], \\\",\\\",  StyleBox[\\\"eps\\\", \
 \\\"TI\\\"]}], \\\"]\\\"}]\\) uses \\!\\(\\*StyleBox[\\\"eps\\\", \\\"TI\\\"]\
 \\) instead.\"\>", "InformationUsageText",
@@ -7194,7 +7194,7 @@ RowBox[{StyleBox[\\\"expr\\\", \\\"TI\\\"], \\\",\\\",  StyleBox[\\\"eps\\\", \
                     RowBox[{
                     RowBox[{"DualExpand", "[", 
                     RowBox[{"DualNumbers`Private`expr_", ",", 
-                    RowBox[{"DualNumbers`Private`eps_", ":", "\[Epsilon]"}]}],
+                    RowBox[{"DualNumbers`Private`eps_", ":", "\[CurlyEpsilon]"}]}],
                      "]"}], ":=", 
                     RowBox[{
                     "DualNumbers`Private`expr", "//.", "\[VeryThinSpace]", 
@@ -7345,7 +7345,7 @@ RowBox[{StyleBox[\\\"expr\\\", \\\"TI\\\"]}], \\\"]\\\"}]\\) replaces each \
 dual number Dual[\\!\\(\\*StyleBox[\\\"a\\\", \\\"TI\\\"]\\), \
 \\!\\(\\*StyleBox[\\\"b\\\", \\\"TI\\\"]\\)] with \
 \\!\\(\\*StyleBox[\\\"a\\\", \\\"TI\\\"]\\) + \\!\\(\\*StyleBox[\\\"b\\\", \\\
-\"TI\\\"]\\) \[Epsilon].\\n\\!\\(\\*RowBox[{\\\"DualExpand\\\", \\\"[\\\", \
+\"TI\\\"]\\) \[CurlyEpsilon].\\n\\!\\(\\*RowBox[{\\\"DualExpand\\\", \\\"[\\\", \
 RowBox[{StyleBox[\\\"expr\\\", \\\"TI\\\"], \\\",\\\",  StyleBox[\\\"eps\\\", \
 \\\"TI\\\"]}], \\\"]\\\"}]\\) uses \\!\\(\\*StyleBox[\\\"eps\\\", \\\"TI\\\"]\
 \\) instead.\"\>", "InformationUsageText",
@@ -7415,7 +7415,7 @@ RowBox[{StyleBox[\\\"expr\\\", \\\"TI\\\"], \\\",\\\",  StyleBox[\\\"eps\\\", \
     "\!\(\*RowBox[{\"DualExpand\", \"[\", RowBox[{StyleBox[\"expr\", \
 \"TI\"]}], \"]\"}]\) replaces each dual number Dual[\!\(\*StyleBox[\"a\", \
 \"TI\"]\), \!\(\*StyleBox[\"b\", \"TI\"]\)] with \!\(\*StyleBox[\"a\", \
-\"TI\"]\) + \!\(\*StyleBox[\"b\", \"TI\"]\) \[Epsilon].\n\
+\"TI\"]\) + \!\(\*StyleBox[\"b\", \"TI\"]\) \[CurlyEpsilon].\n\
 \!\(\*RowBox[{\"DualExpand\", \"[\", RowBox[{StyleBox[\"expr\", \"TI\"], \
 \",\",  StyleBox[\"eps\", \"TI\"]}], \"]\"}]\) uses \!\(\*StyleBox[\"eps\", \
 \"TI\"]\) instead.", "Documentation" -> None, "OwnValues" -> None, "UpValues" -> 
@@ -7426,7 +7426,7 @@ RowBox[{StyleBox[\\\"expr\\\", \\\"TI\\\"], \\\",\\\",  StyleBox[\\\"eps\\\", \
           Blank[]], 
          Optional[
           Pattern[DualNumbers`Private`eps, 
-           Blank[]], DualNumbers`\[Epsilon]]] :> 
+           Blank[]], DualNumbers`\[CurlyEpsilon]]] :> 
        ReplaceRepeated[DualNumbers`Private`expr, DualNumbers`Dual[
            Pattern[DualNumbers`Private`a, 
             Blank[]], 
@@ -7469,7 +7469,7 @@ Cell[BoxData[
             
             StyleBox["\<\"\\!\\(\\*RowBox[{\\\"DualFactor\\\", \\\"[\\\", \
 RowBox[{StyleBox[\\\"expr\\\", \\\"TI\\\"]}], \\\"]\\\"}]\\) replaces \
-\[Epsilon] with Dual[0, 1] in \\!\\(\\*StyleBox[\\\"expr\\\", \\\"TI\\\"]\\).\
+\[CurlyEpsilon] with Dual[0, 1] in \\!\\(\\*StyleBox[\\\"expr\\\", \\\"TI\\\"]\\).\
 \\n\\!\\(\\*RowBox[{\\\"DualFactor\\\", \\\"[\\\", \
 RowBox[{StyleBox[\\\"expr\\\", \\\"TI\\\"], \\\",\\\",  StyleBox[\\\"eps\\\", \
 \\\"TI\\\"]}], \\\"]\\\"}]\\) uses \\!\\(\\*StyleBox[\\\"eps\\\", \\\"TI\\\"]\
@@ -7502,7 +7502,7 @@ RowBox[{StyleBox[\\\"expr\\\", \\\"TI\\\"], \\\",\\\",  StyleBox[\\\"eps\\\", \
                     RowBox[{
                     RowBox[{"DualFactor", "[", 
                     RowBox[{"DualNumbers`Private`expr_", ",", 
-                    RowBox[{"DualNumbers`Private`eps_", ":", "\[Epsilon]"}]}],
+                    RowBox[{"DualNumbers`Private`eps_", ":", "\[CurlyEpsilon]"}]}],
                      "]"}], ":=", 
                     RowBox[{
                     "DualNumbers`Private`expr", "//.", "\[VeryThinSpace]", 
@@ -7643,7 +7643,7 @@ RowBox[{StyleBox[\\\"expr\\\", \\\"TI\\\"], \\\",\\\",  StyleBox[\\\"eps\\\", \
             
             StyleBox["\<\"\\!\\(\\*RowBox[{\\\"DualFactor\\\", \\\"[\\\", \
 RowBox[{StyleBox[\\\"expr\\\", \\\"TI\\\"]}], \\\"]\\\"}]\\) replaces \
-\[Epsilon] with Dual[0, 1] in \\!\\(\\*StyleBox[\\\"expr\\\", \\\"TI\\\"]\\).\
+\[CurlyEpsilon] with Dual[0, 1] in \\!\\(\\*StyleBox[\\\"expr\\\", \\\"TI\\\"]\\).\
 \\n\\!\\(\\*RowBox[{\\\"DualFactor\\\", \\\"[\\\", \
 RowBox[{StyleBox[\\\"expr\\\", \\\"TI\\\"], \\\",\\\",  StyleBox[\\\"eps\\\", \
 \\\"TI\\\"]}], \\\"]\\\"}]\\) uses \\!\\(\\*StyleBox[\\\"eps\\\", \\\"TI\\\"]\
@@ -7712,7 +7712,7 @@ RowBox[{StyleBox[\\\"expr\\\", \\\"TI\\\"], \\\",\\\",  StyleBox[\\\"eps\\\", \
    Association[
    "ObjectType" -> "Symbol", "Usage" -> 
     "\!\(\*RowBox[{\"DualFactor\", \"[\", RowBox[{StyleBox[\"expr\", \
-\"TI\"]}], \"]\"}]\) replaces \[Epsilon] with Dual[0, 1] in \
+\"TI\"]}], \"]\"}]\) replaces \[CurlyEpsilon] with Dual[0, 1] in \
 \!\(\*StyleBox[\"expr\", \"TI\"]\).\n\!\(\*RowBox[{\"DualFactor\", \"[\", \
 RowBox[{StyleBox[\"expr\", \"TI\"], \",\",  StyleBox[\"eps\", \"TI\"]}], \
 \"]\"}]\) uses \!\(\*StyleBox[\"eps\", \"TI\"]\) instead.", "Documentation" -> 
@@ -7723,7 +7723,7 @@ RowBox[{StyleBox[\"expr\", \"TI\"], \",\",  StyleBox[\"eps\", \"TI\"]}], \
           Blank[]], 
          Optional[
           Pattern[DualNumbers`Private`eps, 
-           Blank[]], DualNumbers`\[Epsilon]]] :> 
+           Blank[]], DualNumbers`\[CurlyEpsilon]]] :> 
        ReplaceRepeated[
         DualNumbers`Private`expr, DualNumbers`Private`eps :> 
          DualNumbers`Dual[0, 1]]}], "SubValues" -> None, "DefaultValues" -> 
@@ -7761,7 +7761,7 @@ Cell[BoxData[
             
             StyleBox["\<\"\\!\\(\\*RowBox[{\\\"DualSimplify\\\", \\\"[\\\", \
 RowBox[{StyleBox[\\\"expr\\\", \\\"TI\\\"]}], \\\"]\\\"}]\\) expands \
-\\!\\(\\*StyleBox[\\\"expr\\\", \\\"TI\\\"]\\) around \[Epsilon] = 0, keeping \
+\\!\\(\\*StyleBox[\\\"expr\\\", \\\"TI\\\"]\\) around \[CurlyEpsilon] = 0, keeping \
 only the 0th and 1st order terms.\\n\\!\\(\\*RowBox[{\\\"DualSimplify\\\", \\\
 \"[\\\", RowBox[{StyleBox[\\\"expr\\\", \\\"TI\\\"], \\\",\\\",  \
 StyleBox[\\\"eps\\\", \\\"TI\\\"]}], \\\"]\\\"}]\\) uses \\!\\(\\*StyleBox[\\\
@@ -7795,7 +7795,7 @@ StyleBox[\\\"eps\\\", \\\"TI\\\"]}], \\\"]\\\"}]\\) uses \\!\\(\\*StyleBox[\\\
                     RowBox[{
                     RowBox[{"DualSimplify", "[", 
                     RowBox[{"DualNumbers`Private`expr_", ",", 
-                    RowBox[{"DualNumbers`Private`eps_", ":", "\[Epsilon]"}]}],
+                    RowBox[{"DualNumbers`Private`eps_", ":", "\[CurlyEpsilon]"}]}],
                      "]"}], ":=", 
                     RowBox[{"Normal", "[", 
                     RowBox[{"Series", "[", 
@@ -7938,7 +7938,7 @@ StyleBox[\\\"eps\\\", \\\"TI\\\"]}], \\\"]\\\"}]\\) uses \\!\\(\\*StyleBox[\\\
             
             StyleBox["\<\"\\!\\(\\*RowBox[{\\\"DualSimplify\\\", \\\"[\\\", \
 RowBox[{StyleBox[\\\"expr\\\", \\\"TI\\\"]}], \\\"]\\\"}]\\) expands \
-\\!\\(\\*StyleBox[\\\"expr\\\", \\\"TI\\\"]\\) around \[Epsilon] = 0, keeping \
+\\!\\(\\*StyleBox[\\\"expr\\\", \\\"TI\\\"]\\) around \[CurlyEpsilon] = 0, keeping \
 only the 0th and 1st order terms.\\n\\!\\(\\*RowBox[{\\\"DualSimplify\\\", \\\
 \"[\\\", RowBox[{StyleBox[\\\"expr\\\", \\\"TI\\\"], \\\",\\\",  \
 StyleBox[\\\"eps\\\", \\\"TI\\\"]}], \\\"]\\\"}]\\) uses \\!\\(\\*StyleBox[\\\
@@ -8009,7 +8009,7 @@ StyleBox[\\\"eps\\\", \\\"TI\\\"]}], \\\"]\\\"}]\\) uses \\!\\(\\*StyleBox[\\\
    "ObjectType" -> "Symbol", "Usage" -> 
     "\!\(\*RowBox[{\"DualSimplify\", \"[\", RowBox[{StyleBox[\"expr\", \
 \"TI\"]}], \"]\"}]\) expands \!\(\*StyleBox[\"expr\", \"TI\"]\) around \
-\[Epsilon] = 0, keeping only the 0th and 1st order terms.\n\
+\[CurlyEpsilon] = 0, keeping only the 0th and 1st order terms.\n\
 \!\(\*RowBox[{\"DualSimplify\", \"[\", RowBox[{StyleBox[\"expr\", \"TI\"], \
 \",\",  StyleBox[\"eps\", \"TI\"]}], \"]\"}]\) uses \!\(\*StyleBox[\"eps\", \
 \"TI\"]\) as symbol for the dual unit.", "Documentation" -> None, "OwnValues" -> 
@@ -8020,7 +8020,7 @@ StyleBox[\\\"eps\\\", \\\"TI\\\"]}], \\\"]\\\"}]\\) uses \\!\\(\\*StyleBox[\\\
           Blank[]], 
          Optional[
           Pattern[DualNumbers`Private`eps, 
-           Blank[]], DualNumbers`\[Epsilon]]] :> Normal[
+           Blank[]], DualNumbers`\[CurlyEpsilon]]] :> Normal[
          Series[DualNumbers`Private`expr, {DualNumbers`Private`eps, 0, 1}]]}],
      "SubValues" -> None, "DefaultValues" -> 
     Information`InformationValueForm[

--- a/README.md
+++ b/README.md
@@ -49,26 +49,26 @@ One way to accomplish this task of keeping track of derivatives, is to implement
 Dual numbers are somewhat similar to complex numbers in that they can be written in the form:
 
 ```
-d == a + b ϵ
+d == a + b ε
 ```
 
-where `ϵ`, (like the imaginary unit `i`) is a new number not found on the real line. It is defined by the property that `ϵ^2 == 0`, but `ϵ != 0`.
-You can think of `ϵ` as the algebraic version of an infinitesimal. So a dual number can be considered to be a tuple of 2 real numbers (`a` and `b`) that in this package will be represented as: 
+where `ε`, (like the imaginary unit `i`) is a new number not found on the real line. It is defined by the property that `ε^2 == 0`, but `ε != 0`.
+You can think of `ε` as the algebraic version of an infinitesimal. So a dual number can be considered to be a tuple of 2 real numbers (`a` and `b`) that in this package will be represented as: 
 
 ```
 Dual[a, b]
 ```
 
 The first argument `a` will be called the *standard* part while the second argument `b` will be called the *nonstandard* part (this terminology has been borrowed from [nonstandard analysis](https://en.wikipedia.org/wiki/Nonstandard_analysis)). 
-You can add and multiply duals much like normal numbers. The standard part behaves exactly as real numbers would and will never be influenced by the nonstandard part. For this reason, you can think of the standard part as the most important part of a dual number. The nonstandard part, on the other hand, keeps track of the derivative and can be thought of as a very tiny perturbation on the standard part. You can see this by expanding a general function as a Taylor series in `ϵ`:
+You can add and multiply duals much like normal numbers. The standard part behaves exactly as real numbers would and will never be influenced by the nonstandard part. For this reason, you can think of the standard part as the most important part of a dual number. The nonstandard part, on the other hand, keeps track of the derivative and can be thought of as a very tiny perturbation on the standard part. You can see this by expanding a general function as a Taylor series in `ε`:
 
 ```
-In[]:= Normal @ Series[f[a + b ϵ], {ϵ, 0, 4}] /. Power[ϵ, _?(GreaterEqualThan[2])] -> 0
+In[]:= Normal @ Series[f[a + b ε], {ε, 0, 4}] /. Power[ε, _?(GreaterEqualThan[2])] -> 0
 
-Out[]= f[a] + b ϵ f'[a]
+Out[]= f[a] + b ε f'[a]
 ```
 
-Since `ϵ^2 == 0`, the series has only two terms and produces a new dual number `Dual[f[a], b f'[a]]`. So if you call the function as:
+Since `ε^2 == 0`, the series has only two terms and produces a new dual number `Dual[f[a], b f'[a]]`. So if you call the function as:
 
 ```
 f[Dual[a, 1]]
@@ -304,7 +304,7 @@ Out[]= True
     * `AddDualHandling`: specify derivatives for custom functions to be used with dual numbers.
     * `DualFindRoot`, `FindDualSolution`, `DualFindMinimum`, `DualFindMaximum`: solve equations and optimization problems involving dual numbers.
     * `PackDualArray`, `UnpackDualArray`: convert dual arrays between the packed form `Dual[_List, _List]` and the unpacked form (i.e., a normal array with dual numbers at the deepest level).
-    * `DualExpand`, `DualFactor`, `DualSimplify`: convert back and forth between the programmatic form `Dual[_, _]` and the algebraic form `a + b ϵ`.
+    * `DualExpand`, `DualFactor`, `DualSimplify`: convert back and forth between the programmatic form `Dual[_, _]` and the algebraic form `a + b ε`.
 	* `DualTuples`, `DualTuplesReduce`: For a list of dual numbers, find all ways to pick the nonstandard part from one dual number and the standard part from the other ones.
 
 ## Know issues and limitations


### PR DESCRIPTION
In all literature on dual numbers ε is the standard symbol for
"epsilon", not the lunate form ϵ. Additionally in its analog for the
infinitesimal, the standard throughout mathematics at least in recent
centuries has been ε.